### PR TITLE
Update Header.tsx with current veYFI docs link

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -91,7 +91,7 @@ const nav: TMenu[] = [
 	{path: '/', label: 'veYFI'},
 	{path: 'https://snapshot.org/#/veyfi.eth', label: 'Snapshot', target: '_blank'},
 	{
-		path: 'https://docs.yearn.fi/getting-started/products/veyfi',
+		path: 'https://docs.yearn.fi/contributing/governance/veYFI-intro',
 		label: 'Docs',
 		target: '_blank'
 	}


### PR DESCRIPTION
## Description

Changed docs link href to current address. Existing link is outdated.

## Related Issue

none

## Motivation and Context

fix link.

## How Has This Been Tested?

n/a

## Screenshots (if appropriate):
