### PR TITLE
fix: invalid network bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The Next.js app lives under `app/`, with domain modules grouped in folders such as `components/`, `hooks/`, `contexts/`, and `icons/`. Shared utilities and contract ABIs sit in `app/utils.ts` and `app/abi/`. Legacy route handlers remain in `pages/` for backwards-compatible paths. Static assets (SVGs, favicons, service worker output) are served from `public/`, while global styles and Tailwind layers are in `style.css` and `tailwind.config.js`. Keep new feature code close to its consumer module and prefer colocated components over sprawling shared directories.
+
+## Build, Test, and Development Commands
+Use Yarn for scripting: `yarn dev` launches the local dev server, and `yarn inspect` starts Next.js with the Node inspector enabled. Run type-checking with `yarn dev:ts`, and ship builds through `yarn build` or the production bundle via `yarn start`. For static exports (used for IPFS deployments), run `yarn export`. Lint the project with `yarn lint`, format with `yarn prettier-format`, and enforce style checks with `yarn prettier` before opening a PR.
+
+## Coding Style & Naming Conventions
+Prettier rules mandate tabs (width 4), single quotes, semicolons, bracket-same-line JSX, and 120-character line wraps. ESLint extends `@yearn-finance/web-lib`, `next`, and Tailwind plugins—expect warnings for unsorted imports, unused dependencies, and missing hook deps. Prefer PascalCase for components, camelCase for hooks/utilities, and SCREAMING_SNAKE_CASE for constants. Tailwind classes should stay semantically grouped, and all time-sensitive config defaults belong in `app/contexts/`.
+
+## Testing Guidelines
+Vitest backs the automated test suite (`yarn test`). Add React-facing tests with `@testing-library/react` and colocate them in `__tests__` directories inside the relevant feature folder (for example, `app/components/LockForm/__tests__/LockForm.spec.tsx`). Write deterministic tests that cover edge cases around veYFI lock durations, API fallbacks, and wallet connectivity flows. Include meaningful names (`should_render_error_on_invalid_amount`) and update snapshots when intentional UI changes occur.
+
+## Commit & Pull Request Guidelines
+Follow the existing Conventional Commit style (`feat:`, `fix:`, `chore:`, etc.) and keep messages imperative and scoped to a single change. Rebase onto `main` before opening a PR, then provide a concise summary, screenshots of UI adjustments, and links to Notion issues or GitHub tickets. Mention any configuration or env variable changes and paste the output of `yarn lint`/`yarn test` for reviewer context. PRs should stay small enough for a quick review and include a checklist of follow-up tasks when necessary.
+
+## Environment & Security Notes
+Copy `.env.example` into `.env` and populate required RPC URLs and API keys. Never commit secrets; rely on Vercel project settings for production values. When touching wallet or contract logic, confirm ABI updates in `app/abi/` and run manual smoke tests on a forked network before merging.

--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,7 @@ const config = {
 		 ** Config over the RPC
 		 **********************************************************************/
 		WEB_SOCKET_URL: {
-			1: process.env.WS_URL_MAINNET,
+			1: process.env.WS_URL_MAINNET || 'wss://ethereum-rpc.publicnode.com',
 			10: process.env.WS_URL_OPTIMISM,
 			137: process.env.WS_URL_POLYGON,
 			250: process.env.WS_URL_FANTOM,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import localFont from 'next/font/local';
 import Head from 'next/head';
 import AppHeader from 'app/components/common/Header';
@@ -10,6 +10,8 @@ import {GaugeContextApp} from 'app/contexts/useGauge';
 import {OptionContextApp} from 'app/contexts/useOption';
 import {VotingEscrowContextApp} from 'app/contexts/useVotingEscrow';
 import {YearnContextApp} from 'app/contexts/useYearn';
+import {useDisconnect} from 'wagmi';
+import {useWeb3} from '@builtbymom/web3/contexts/useWeb3';
 import {WithMom} from '@builtbymom/web3/contexts/WithMom';
 import {cl} from '@builtbymom/web3/utils/cl';
 import {mainnet} from '@wagmi/chains';
@@ -41,6 +43,34 @@ const aeonik = localFont({
 		}
 	]
 });
+
+function WalletConnectionGuard(): ReactElement | null {
+	const {address, isActive, provider} = useWeb3();
+	const {disconnect} = useDisconnect();
+
+	useEffect(() => {
+		if (!address || isActive) {
+			return;
+		}
+		const connectorId =
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			((provider as any)?.id || (provider as any)?._wallets?.[0]?.id || '') as string;
+		const shouldReset = typeof connectorId === 'string' && connectorId.toLowerCase().includes('walletconnect');
+		const hasLostProvider = !provider;
+		if (!shouldReset && !hasLostProvider) {
+			return;
+		}
+		const timer = window.setTimeout(() => {
+			if (!isActive && address) {
+				console.warn('[wallet] Resetting stalled connection to recover from subscription failure');
+				disconnect();
+			}
+		}, 1500);
+		return (): void => window.clearTimeout(timer);
+	}, [address, disconnect, isActive, provider]);
+
+	return null;
+}
 
 function AppWrapper(props: AppProps & {supportedNetworks: Chain[]}): ReactElement {
 	const {Component, pageProps} = props;
@@ -124,6 +154,7 @@ function MyApp(props: AppProps): ReactElement {
 											supportedNetworks={supportedNetworks}
 											{...props}
 										/>
+										<WalletConnectionGuard />
 									</main>
 								</main>
 							</OptionContextApp>


### PR DESCRIPTION
## Description

Occasionally users were unable to connect and shown an "Invalid Network" error in the wallet connector and couldn't remove it.

<img width="1280" height="270" alt="image" src="https://github.com/user-attachments/assets/5badfaf1-dbc2-4d6b-ba79-23dfca1b0983" />

Patched the wallet bootstrap to default to a working WSS endpoint and added a guard that recovers from failed WalletConnect sessions.

- next.config.js:75 now injects wss://ethereum-rpc.publicnode.com when WS_URL_MAINNET is absent so RainbowKit always receives a valid WebSocket transport.
- pages/_app.tsx:1 extends the app imports with useWeb3, useEffect, and useDisconnect for the new connection guard.
- pages/_app.tsx:47 introduces WalletConnectionGuard, which watches the web3 context and, on stalled WalletConnect or missing provider states, logs a warning and disconnects so the user can reconnect cleanly.

Also adds an AGENTS.md file.

The work for this PR was mostly done by CODEX 🤖 

## Related Issue

none

## Motivation and Context

Make bug go away

## How Has This Been Tested?

locally

## Screenshots (if appropriate):
